### PR TITLE
BREAKING: Add state labels, rename existing consts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Shared Golang package for Nagios plugins
 
 This package contains common types and package-level variables used when
 developing Nagios plugins. The intent is to reduce code duplication between
-various plugins.
+various plugins and help reduce typos associated with literal strings.
 
 ## Features
 
@@ -42,12 +42,20 @@ import (
 )
   ```
 
-Then in your code reference the data types as you would from any other
+Then in your code, reference the data types as you would from any other
 package:
 
 ```golang
 fmt.Println("OK: All checks have passed")
-os.Exit(nagios.StateOK)
+os.Exit(nagios.StateOKExitCode)
+```
+
+Alternatively, you can also use the provided state "labels" (constants) to
+avoid using literal string state values:
+
+```golang
+fmt.Printf("%s: All checks have passed\r\n", nagios.StateOKLabel)
+os.Exit(nagios.StateOKExitCode)
 ```
 
 When you next build your package this one should be pulled in.

--- a/main.go
+++ b/main.go
@@ -18,9 +18,20 @@ package nagios
 //
 // See also http://nagios-plugins.org/doc/guidelines.html
 const (
-	StateOK        int = 0
-	StateWARNING   int = 1
-	StateCRITICAL  int = 2
-	StateUNKNOWN   int = 3
-	StateDEPENDENT int = 4
+	StateOKExitCode        int = 0
+	StateWARNINGExitCode   int = 1
+	StateCRITICALExitCode  int = 2
+	StateUNKNOWNExitCode   int = 3
+	StateDEPENDENTExitCode int = 4
+)
+
+// Nagios plugin/service check state "labels". These constants are provided as
+// an alternative to using literal state strings throughout client application
+// code.
+const (
+	StateOKLabel        string = "OK"
+	StateWARNINGLabel   string = "WARNING"
+	StateCRITICALLabel  string = "CRITICAL"
+	StateUNKNOWNLabel   string = "UKNOWN"
+	StateDEPENDENTLabel string = "DEPENDENT"
 )


### PR DESCRIPTION
- Rename existing exit code constants to explicitly note that
  they are exit codes.
  - This is a BREAKING change, but according to godoc.org there
    is only one consumer of this package thus far and it is one
    that I maintain (PR incoming there soon)

- Add constants for state "labels" to help reduce typos when
  referencing output text strings like "OK", "WARNING", etc.

I believe that further refinement is needed here once I better
understand the various use cases.

fixes GH-16