### PR TITLE
go.mod | Update Go version from 1.13 to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/atc0005/go-nagios
 
-go 1.13
+go 1.14


### PR DESCRIPTION
- Update "oldstable" Go version
- go mod tidy