### PR TITLE
Fix GHAW build depth

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -82,4 +82,4 @@ jobs:
 
       - name: Build using vendored dependencies (if applicable)
         run: |
-          go build -v -mod=vendor .
+          go build -v -mod=vendor ./...


### PR DESCRIPTION
Restore the previous build depth before the work on GH-21. This reverses the unintentional change made to this command as part of commit 90974cf5cdd507b967c9511fd93f38b68e0a759b.

- fixes GH-32
- refs GH-21, GH-28