### PR TITLE
Do not assume that state thresholds will be given

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -147,8 +147,18 @@ func (es ExitState) ReturnCheckResults() {
 				CheckOutputEOL, CheckOutputEOL, CheckOutputEOL,
 			)
 
-			fmt.Printf("* %v%s", es.CriticalThreshold, CheckOutputEOL)
-			fmt.Printf("* %v%s", es.WarningThreshold, CheckOutputEOL)
+			if es.CriticalThreshold != "" || es.WarningThreshold != "" {
+
+				if es.CriticalThreshold != "" {
+					fmt.Printf("* %v%s", es.CriticalThreshold, CheckOutputEOL)
+				}
+
+				if es.WarningThreshold != "" {
+					fmt.Printf("* %v%s", es.WarningThreshold, CheckOutputEOL)
+				}
+			} else {
+				fmt.Printf("* Not defined%s", CheckOutputEOL)
+			}
 
 			fmt.Printf("%s**DETAILED INFO**%s", CheckOutputEOL, CheckOutputEOL)
 


### PR DESCRIPTION
Conditionally display provided thresholds, or note that they are not defined. This prevents empty list items from showing in the `Long Service Output` section. Without an explicit value of some kind, it gives the impression that a bug has prevented the information from showing.

fixes GH-37