### PR TITLE
Update method to work properly when deferred

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -95,27 +95,29 @@ type ExitState struct {
 	BrandingCallback ExitCallBackFunc
 }
 
-// ReturnCheckResults is intended to be called with the defer keyword.
+// ReturnCheckResults is intended to provide a reliable way to return a
+// desired exit code from applications used as Nagios plugins. In most cases,
+// this method should be registered as the first deferred function in client
+// code.
 //
-// Nagios relies on plugin exit codes to determine success/failure of checks;
-// in order to safely apply a final exit code without halting normal program
-// execution the defer keyword is used to allow this function to execute after
-// normal program execution completes.
-//
-// The approach that is most often used with other languages is to use
+// Since Nagios relies on plugin exit codes to determine success/failure of
+// checks, the approach that is most often used with other languages is to use
 // something like Using os.Exit() directly and force an early exit of the
 // application with an explicit exit code. Using os.Exit() directly in Go does
-// not run deferred functions; other Go-based plugins that do not rely on
-// deferring function calls may get away with using os.Exit(), but introducing
-// new dependencies could introduce problems.
+// not run deferred functions. Go-based plugins that do not rely on deferring
+// function calls may be able to use os.Exit(), but introducing new
+// dependencies later could introduce problems if those dependencies rely on
+// deferring functions.
 //
-// We attempt to explicitly allow deferred functions to work as intended
-// by queuing up values as the app runs and then have this block of code
-// scheduled (deferred) to process those queued values, including the
-// intended plugin exit state. Since this codeblock runs as the last step
-// in the application, it can safely call os.Exit() to set the desired
-// exit code without blocking other deferred functions from running.
-func (es ExitState) ReturnCheckResults() {
+// Before calling this method, client code should first set appropriate field
+// values on the receiver. When called, this method will process them and exit
+// with the desired exit code and status output.
+//
+// To repeat, if scheduled via defer, this method should be registered first;
+// because this method calls os.Exit to set the intended plugin exit state, no
+// other deferred functions will have an opportunity to run, so register this
+// method first so that when deferred, it will be run last (FILO).
+func (es *ExitState) ReturnCheckResults() {
 
 	// ##################################################################
 	// Note: fmt.Println() has the same issue as `\n`: Nagios seems to


### PR DESCRIPTION
- Change receiver type to allow early deferral of method
  before field values have been fully set.

- Update documentation to heavily emphasize early deferral
  registration in order to allow other deferred functions to
  run as intended.

fixes GH-44