### PR TITLE
Fix breadcrumb URL

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/go-nagios
+# https://github.com/atc0005/go-nagios
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.


### PR DESCRIPTION
At some point I made a search/replace operation that
unintentionally replaced the `//` characters in the project
URL with a hash mark.

I seem to have caught/corrected the other cases, but this one
was left behind.

Minor fix to sort that.