### PR TITLE
Explicitly emit ServiceOutput as-is

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -164,13 +164,16 @@ func (es *ExitState) ReturnCheckResults() {
 	// ##################################################################
 	// Note: fmt.Println() has the same issue as `\n`: Nagios seems to
 	// interpret them literally instead of emitting an actual newline.
-	// We work around that by using fmt.Printf() for output that is
-	// intended for display within the Nagios web UI.
+	// We work around that by using fmt.Printf() and fmt.Print() for
+	// output that is intended for display within the Nagios web UI.
 	// ##################################################################
 
 	// One-line output used as the summary or short explanation for the
-	// specific Nagios state that we are returning.
-	fmt.Printf(es.ServiceOutput)
+	// specific Nagios state that we are returning. We apply no formatting
+	// changes to this content, simply emit it as-is. This helps avoid
+	// potential issues with literal characters being interpreted as
+	// formatting verbs.
+	fmt.Print(es.ServiceOutput)
 
 	if es.LongServiceOutput != "" || es.LastError != nil {
 


### PR DESCRIPTION
Treat `ServiceOutput` field content as preformatted text, skipping potential false-positive handling of literal values
as formatting verbs. In particular, this avoids treating lone `%` values as a formatting verb prefix.

fixes GH-58