### PR TITLE
Provide complete stack trace instead of snippet

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -12,7 +12,7 @@ package nagios
 import (
 	"fmt"
 	"os"
-	"runtime"
+	"runtime/debug"
 )
 
 // Nagios plugin/service check states. These constants replicate the values
@@ -141,11 +141,8 @@ func (es *ExitState) ReturnCheckResults() {
 			StateCRITICALLabel,
 		)
 
-		// Gather stack trace associated with panic for display.
-		// NOTE: runtime.Stack *requires* that we preallocate the slice and
-		// with zero values.
-		stackTrace := make([]byte, 512)
-		stackTraceSize := runtime.Stack(stackTrace, false)
+		// Gather stack trace associated with panic.
+		stackTrace := debug.Stack()
 
 		// Wrap stack trace details in an attempt to prevent these details
 		// from being interpreted as formatting characters when passed through
@@ -158,7 +155,7 @@ func (es *ExitState) ReturnCheckResults() {
 			err,
 			CheckOutputEOL,
 			CheckOutputEOL,
-			stackTrace[0:stackTraceSize],
+			stackTrace,
 			CheckOutputEOL,
 		)
 


### PR DESCRIPTION
There have been several cases where not having the full
stack trace has hindered troubleshooting efforts, so opting
to return the complete trace instead of a truncated snippet.

This behavior is subject to change again in the future (e.g.,
if some massive trace is captured and reported causing
further issues).

fixes GH-68