### PR TITLE
Fix typo in UNKNOWN state label constant

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -38,7 +38,7 @@ const (
 	StateOKLabel        string = "OK"
 	StateWARNINGLabel   string = "WARNING"
 	StateCRITICALLabel  string = "CRITICAL"
-	StateUNKNOWNLabel   string = "UKNOWN"
+	StateUNKNOWNLabel   string = "UNKNOWN"
 	StateDEPENDENTLabel string = "DEPENDENT"
 )
 


### PR DESCRIPTION
Credit: Code Spell Checker VSCode extension.

fixes GH-82