### PR TITLE
Fix typo in CHANGELOG release tags list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,7 +271,7 @@ Initial package state
 - Nagios state map
 
 [Unreleased]: https://github.com/atc0005/go-nagios/compare/v0.7.0...HEAD
-[v0.6.1]: https://github.com/atc0005/go-nagios/releases/tag/v0.7.0
+[v0.7.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.7.0
 [v0.6.1]: https://github.com/atc0005/go-nagios/releases/tag/v0.6.1
 [v0.6.0]: https://github.com/atc0005/go-nagios/releases/tag/v0.6.0
 [v0.5.3]: https://github.com/atc0005/go-nagios/releases/tag/v0.5.3


### PR DESCRIPTION
Accidentally duplicated the v0.6.1 tag ref link text.