### PR TITLE
Only emit Performance Data when (complete) plugin data present

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -342,7 +342,7 @@ func (es *ExitState) ReturnCheckResults() {
 		// Performance data metrics are appended to plugin output. These
 		// metrics are provided as a single line, leading with a pipe
 		// character, a space and one or more metrics each separated from
-		// another by a single space. single space.
+		// another by a single space.
 		fmt.Print(" |")
 
 		for _, pd := range es.perfData {

--- a/nagios.go
+++ b/nagios.go
@@ -335,8 +335,9 @@ func (es *ExitState) ReturnCheckResults() {
 		fmt.Printf("%s%s%s", CheckOutputEOL, es.BrandingCallback(), CheckOutputEOL)
 	}
 
-	// Generate formatted performance data if provided.
-	if len(es.perfData) != 0 {
+	// Generate formatted performance data if provided. Only emit if a
+	// one-line summary is set by client code.
+	if len(es.perfData) != 0 && es.ServiceOutput != "" {
 
 		// Performance data metrics are appended to plugin output. These
 		// metrics are provided as a single line, leading with a pipe


### PR DESCRIPTION
Emit Performance Data when available AND when `ServiceOutput` is set. This guards against emitting metrics when there isn't valid (complete) plugin data to process.

- fixes GH-98
- refs atc0005/check-vmware#473