### PR TITLE
Use length check for perfdata instead of nil check

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -384,7 +384,7 @@ func (es *ExitState) ReturnCheckResults() {
 // directly.
 func (es *ExitState) AddPerfData(skipValidate bool, pd ...PerformanceData) error {
 
-	if pd == nil {
+	if len(pd) == 0 {
 		return fmt.Errorf("no performance data provided")
 	}
 


### PR DESCRIPTION
This change accounts for the potential to receive an empty slice in addition to a nil slice (as we were checking for prior to this change).

fixes GH-104
