### PR TITLE
Fix incorrect interpolation order for labels

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -305,9 +305,9 @@ func (es *ExitState) ReturnCheckResults() {
 
 		fmt.Printf(
 			"%s%s**%s**%s",
+			CheckOutputEOL,
+			CheckOutputEOL,
 			es.getErrorsLabelText(),
-			CheckOutputEOL,
-			CheckOutputEOL,
 			CheckOutputEOL,
 		)
 
@@ -333,8 +333,8 @@ func (es *ExitState) ReturnCheckResults() {
 
 			fmt.Printf(
 				"%s**%s**%s",
-				es.getThresholdsLabelText(),
 				CheckOutputEOL,
+				es.getThresholdsLabelText(),
 				CheckOutputEOL,
 			)
 
@@ -365,8 +365,8 @@ func (es *ExitState) ReturnCheckResults() {
 
 			fmt.Printf(
 				"%s**%s**%s",
-				es.getDetailedInfoLabelText(),
 				CheckOutputEOL,
+				es.getDetailedInfoLabelText(),
 				CheckOutputEOL,
 			)
 


### PR DESCRIPTION
Commit f0c9c497bfccbdfc0e4a3dc5d45efeffd93cd054 applied an
incorrect interpolation order for the (potentially custom)
section header/label values.

This commit updates the order so that the label text is placed
within the formatting characters as intended.

- fixes GH-107
- refs GH-119