### PR TITLE
Emit `Service Output` as-is

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -337,7 +337,7 @@ func (es *ExitState) ReturnCheckResults() {
 	// changes to this content, simply emit it as-is. This helps avoid
 	// potential issues with literal characters being interpreted as
 	// formatting verbs.
-	fmt.Fprintf(&output, es.ServiceOutput)
+	fmt.Fprint(&output, es.ServiceOutput)
 
 	es.handleErrorsSection(&output)
 


### PR DESCRIPTION
Fix unintentional handling of Service Output from client code as potentially containing formatt specifier (i.e., formatting "verbs") by explicitly emitting content as-is.

This fixes a regression introduced by the v0.9.0 release that was introduced by bulk refactoring work.

- fixes GH-139
- refs GH-58