### PR TITLE
Prevent further Service Output interpolation regressions

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -292,6 +292,13 @@ func (es *ExitState) ReturnCheckResults() {
 
 	var output strings.Builder
 
+	// ##################################################################
+	// Note: fmt.Println() (and fmt.Fprintln()) has the same issue as `\n`:
+	// Nagios seems to interpret them literally instead of emitting an actual
+	// newline. We work around that by using fmt.Fprintf() and fmt.Fprint()
+	// for output that is intended for display within the Nagios web UI.
+	// ##################################################################
+
 	// Check for unhandled panic in client code. If present, override
 	// ExitState and make clear that the client code/plugin crashed.
 	if err := recover(); err != nil {
@@ -325,19 +332,7 @@ func (es *ExitState) ReturnCheckResults() {
 
 	}
 
-	// ##################################################################
-	// Note: fmt.Println() (and fmt.Fprintln()) has the same issue as `\n`:
-	// Nagios seems to interpret them literally instead of emitting an actual
-	// newline. We work around that by using fmt.Fprintf() and fmt.Fprint()
-	// for output that is intended for display within the Nagios web UI.
-	// ##################################################################
-
-	// One-line output used as the summary or short explanation for the
-	// specific Nagios state that we are returning. We apply no formatting
-	// changes to this content, simply emit it as-is. This helps avoid
-	// potential issues with literal characters being interpreted as
-	// formatting verbs.
-	fmt.Fprint(&output, es.ServiceOutput)
+	es.handleServiceOutputSection(&output)
 
 	es.handleErrorsSection(&output)
 

--- a/sections.go
+++ b/sections.go
@@ -12,6 +12,17 @@ import (
 	"io"
 )
 
+// handleServiceOutputSection is a wrapper around the logic used to process
+// the Service Output or "one-line summary" content.
+func (es ExitState) handleServiceOutputSection(w io.Writer) {
+	// One-line output used as the summary or short explanation for the
+	// specific Nagios state that we are returning. We apply no formatting
+	// changes to this content, simply emit it as-is. This helps avoid
+	// potential issues with literal characters being interpreted as
+	// formatting verbs.
+	fmt.Fprint(w, es.ServiceOutput)
+}
+
 // handleErrorsSection is a wrapper around the logic used to handle/process the
 // Errors section header and listing.
 func (es ExitState) handleErrorsSection(w io.Writer) {

--- a/sections.go
+++ b/sections.go
@@ -20,7 +20,7 @@ func (es ExitState) handleServiceOutputSection(w io.Writer) {
 	// changes to this content, simply emit it as-is. This helps avoid
 	// potential issues with literal characters being interpreted as
 	// formatting verbs.
-	fmt.Fprintf(w, es.ServiceOutput)
+	fmt.Fprint(w, es.ServiceOutput)
 }
 
 // handleErrorsSection is a wrapper around the logic used to handle/process the

--- a/sections.go
+++ b/sections.go
@@ -20,7 +20,7 @@ func (es ExitState) handleServiceOutputSection(w io.Writer) {
 	// changes to this content, simply emit it as-is. This helps avoid
 	// potential issues with literal characters being interpreted as
 	// formatting verbs.
-	fmt.Fprint(w, es.ServiceOutput)
+	fmt.Fprintf(w, es.ServiceOutput)
 }
 
 // handleErrorsSection is a wrapper around the logic used to handle/process the

--- a/unexported_test.go
+++ b/unexported_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/go-nagios
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Package nagios provides test coverage for unexported package functionality.
+package nagios
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceOutputIsNotInterpolated is intended to prevent further
+// regressions of formatting being applied to literal/preformatted Service
+// Output (aka, "one-line summary" output).
+//
+// See also:
+//
+// - https://github.com/atc0005/go-nagios/issues/139
+// - https://github.com/atc0005/go-nagios/issues/58
+func TestServiceOutputIsNotInterpolated(t *testing.T) {
+	t.Parallel()
+
+	// Setup ExitState type the same way that client code would.
+	var nagiosExitState = ExitState{
+		LastError:      nil,
+		ExitStatusCode: StateOKExitCode,
+	}
+
+	var output strings.Builder
+
+	// If passed through fmt.Printf, fmt.Fprintf or fmt.Sprintf the '% o'
+	// pattern is treated as a base 8 integer formatting verb. If passed
+	// through fmt.Print or fmt.Fprint the pattern is ignored (as intended).
+	testInput := "OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs)" +
+		" is 0.01% of 18.0TB with 18.0TB remaining" +
+		" [WARNING: 90% , CRITICAL: 95%]"
+
+	// The input from client code is expected to be passed as-is, without
+	// formatting or interpretation of any kind.
+	want := testInput
+	nagiosExitState.ServiceOutput = testInput
+
+	nagiosExitState.handleServiceOutputSection(&output)
+
+	got := output.String()
+
+	if want != got {
+		t.Errorf("\nwant %q\ngot %q", want, got)
+	}
+}


### PR DESCRIPTION
## Overview

Apply a series of changes to help prevent further regressions:

- move Service Output handling logic to helper function
  - consolidate logic in one place similar to how the other output sections (e.g., Errors, Long Service Output) are already handled to make this logic easier to test
- add test case
  - intentionally restore regression by using `fmt.Fprintf` function in helper code
  - fix regression by using `fmt.Fprint` as intended, confirm expected behavior

## References

- GH-58
- GH-139