### PR TITLE
Emit perfdata on same line as ServiceOutput if

### DIFF
--- a/exported_test.go
+++ b/exported_test.go
@@ -19,13 +19,20 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// The specific format used by the test input file is VERY specific; trailing
+// The specific format used by the test input files is VERY specific; trailing
 // space + newline patterns are intentional. Because "format on save" editor
-// functionality easily breaks this input it is stored in a separate file to
+// functionality easily breaks this input it is stored in separate files to
 // reduce test breakage due to editors "helping".
-//
-//go:embed testdata/plugin-output-datastore-0001.txt
-var pluginOutputDatastore0001 string
+var (
+	//go:embed testdata/plugin-output-datastore-0001.txt
+	pluginOutputDatastore0001 string
+
+	//go:embed testdata/plugin-output-gh103-multi-line-with-perf-data.txt
+	pluginOutputGH103MultiLineWithPerfData string
+
+	//go:embed testdata/plugin-output-gh103-one-line-with-perf-data.txt
+	pluginOutputGH103OneLineWithPerfData string
+)
 
 // TestPluginOutputIsValid configures an ExitState value as client code would
 // and then asserts that the generated output matches manually crafted test
@@ -120,6 +127,164 @@ func TestPluginOutputIsValid(t *testing.T) {
 	// if want != got {
 	// 	t.Error(cmp.Diff(want, got))
 	// }
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("(-want, +got)\n:%s", d)
+	}
+}
+
+// TestPerformanceDataIsOnSameLineAsServiceOutput asserts that performance
+// data is emitted on the same line as the Service Output (aka, "one-line
+// summary") if Long Service Output is empty.
+//
+// See also:
+//
+// - https://github.com/atc0005/go-nagios/issues/103
+func TestPerformanceDataIsOnSameLineAsServiceOutput(t *testing.T) {
+	t.Parallel()
+
+	want := pluginOutputGH103OneLineWithPerfData
+
+	// Setup ExitState type the same way that client code would.
+	nagiosExitState := nagios.ExitState{
+		LastError:      nil,
+		ExitStatusCode: nagios.StateOKExitCode,
+	}
+
+	var outputBuffer strings.Builder
+	nagiosExitState.SetOutputTarget(&outputBuffer)
+
+	// os.Exit calls break tests
+	nagiosExitState.SkipOSExit()
+
+	nagiosExitState.ServiceOutput =
+		"OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs)" +
+			" is 0.01% of 18.0TB with 18.0TB remaining" +
+			" [WARNING: 90% , CRITICAL: 95%]"
+
+	pd := nagios.PerformanceData{
+		Label: "time",
+		Value: "874ms",
+	}
+
+	if err := nagiosExitState.AddPerfData(false, pd); err != nil {
+		t.Errorf("failed to add performance data: %v", err)
+	}
+
+	// Process exit state, emit output to our output buffer.
+	nagiosExitState.ReturnCheckResults()
+
+	// Retrieve the output buffer content so that we can compare actual output
+	// against our expected output to assert we have a 1:1 match.
+	got := outputBuffer.String()
+
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("(-want, +got)\n:%s", d)
+	}
+}
+
+// TestPerformanceDataIsAfterLongServiceOutput asserts that performance data
+// is emitted after Long Service Output when that content is available.
+//
+// See also:
+//
+// - https://github.com/atc0005/go-nagios/issues/103
+func TestPerformanceDataIsAfterLongServiceOutput(t *testing.T) {
+	t.Parallel()
+
+	want := pluginOutputGH103MultiLineWithPerfData
+
+	var outputBuffer strings.Builder
+
+	// Setup ExitState type the same way that client code would.
+	nagiosExitState := nagios.ExitState{
+		LastError:      nil,
+		ExitStatusCode: nagios.StateOKExitCode,
+	}
+
+	nagiosExitState.SetOutputTarget(&outputBuffer)
+
+	// os.Exit calls break tests
+	nagiosExitState.SkipOSExit()
+
+	nagiosExitState.CriticalThreshold = fmt.Sprintf(
+		"%d%% datastore usage",
+		95,
+	)
+
+	nagiosExitState.WarningThreshold = fmt.Sprintf(
+		"%d%% datastore usage",
+		90,
+	)
+
+	nagiosExitState.ServiceOutput =
+		"OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs)" +
+			" is 0.01% of 18.0TB with 18.0TB remaining" +
+			" [WARNING: 90% , CRITICAL: 95%]"
+
+	var longServiceOutputReport strings.Builder
+
+	fmt.Fprintf(
+		&longServiceOutputReport,
+		"Datastore Space Summary:%s%s"+
+			"* Name: %s%s"+
+			"* Space Used: %v (%.2f%%)%s"+
+			"* Space Remaining: %v (%.2f%%)%s"+
+			"* VMs: %v %s%s",
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL,
+		"HUSVM-DC1-vol6",
+		nagios.CheckOutputEOL,
+		"2.3GB",
+		0.01,
+		nagios.CheckOutputEOL,
+		"18.0TB",
+		99.99,
+		nagios.CheckOutputEOL,
+		0,
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&longServiceOutputReport,
+		"%s---%s%s",
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&longServiceOutputReport,
+		"* vSphere environment: %s%s",
+		"https://vc1.example.com:443/sdk",
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&longServiceOutputReport,
+		"* Plugin User Agent: %s%s",
+		"check-vmware/v0.30.6-0-g25fdcdc",
+		nagios.CheckOutputEOL,
+	)
+
+	nagiosExitState.LongServiceOutput = longServiceOutputReport.String()
+
+	pd := nagios.PerformanceData{
+		Label: "time",
+		Value: "874ms",
+	}
+
+	if err := nagiosExitState.AddPerfData(false, pd); err != nil {
+		t.Errorf("failed to add performance data: %v", err)
+	}
+
+	// Process exit state, emit output to our output buffer.
+	nagiosExitState.ReturnCheckResults()
+
+	// Retrieve the output buffer content so that we can compare actual output
+	// against our expected output to assert we have a 1:1 match.
+	got := outputBuffer.String()
+
 	if d := cmp.Diff(want, got); d != "" {
 		t.Errorf("(-want, +got)\n:%s", d)
 	}

--- a/sections.go
+++ b/sections.go
@@ -10,15 +10,27 @@ package nagios
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // handleServiceOutputSection is a wrapper around the logic used to process
 // the Service Output or "one-line summary" content.
 func (es ExitState) handleServiceOutputSection(w io.Writer) {
-	// One-line output used as the summary or short explanation for the
-	// specific Nagios state that we are returning. We apply no formatting
-	// changes to this content, simply emit it as-is. This helps avoid
-	// potential issues with literal characters being interpreted as
+	if es.LongServiceOutput == "" {
+		// If Long Service Output was not specified, explicitly trim any
+		// formatted trailing spacing so that performance data output will be
+		// emitted immediately following the Service Output on the same line.
+
+		// NOTE: We explicitly include a space character in the cut set just
+		// on the off chance that a future update to the CheckOutputEOL
+		// constant removes the explicitly leading whitespace character.
+		cutSet := fmt.Sprintf(" \t%s", CheckOutputEOL)
+		es.ServiceOutput = strings.TrimRight(es.ServiceOutput, cutSet)
+	}
+
+	// Aside from (potentially) trimming trailing whitespace, we apply no
+	// formatting changes to this content, simply emit it as-is. This helps
+	// avoid potential issues with literal characters being interpreted as
 	// formatting verbs.
 	fmt.Fprint(w, es.ServiceOutput)
 }

--- a/testdata/plugin-output-gh103-multi-line-with-perf-data.txt
+++ b/testdata/plugin-output-gh103-multi-line-with-perf-data.txt
@@ -1,0 +1,22 @@
+OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs) is 0.01% of 18.0TB with 18.0TB remaining [WARNING: 90% , CRITICAL: 95%] 
+**THRESHOLDS** 
+ 
+* CRITICAL: 95% datastore usage 
+* WARNING: 90% datastore usage 
+ 
+**DETAILED INFO** 
+ 
+Datastore Space Summary: 
+ 
+* Name: HUSVM-DC1-vol6 
+* Space Used: 2.3GB (0.01%) 
+* Space Remaining: 18.0TB (99.99%) 
+* VMs: 0  
+ 
+ 
+--- 
+ 
+* vSphere environment: https://vc1.example.com:443/sdk 
+* Plugin User Agent: check-vmware/v0.30.6-0-g25fdcdc 
+ 
+ | 'time'=874ms;;;; 

--- a/testdata/plugin-output-gh103-one-line-with-perf-data.txt
+++ b/testdata/plugin-output-gh103-one-line-with-perf-data.txt
@@ -1,0 +1,1 @@
+OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs) is 0.01% of 18.0TB with 18.0TB remaining [WARNING: 90% , CRITICAL: 95%] | 'time'=874ms;;;; 


### PR DESCRIPTION
If `LongServiceOutput` is set, emit Performance Data after it as previously done. Otherwise, if not set, emit Performance Data immediately after ServiceOutput.

Add tests and testdata to assert the expected behavior.

fixes GH-103