### PR TITLE
Replace further ExitState references

### DIFF
--- a/example_emit_perfdata_via_deferred_function_test.go
+++ b/example_emit_perfdata_via_deferred_function_test.go
@@ -65,7 +65,7 @@ func Example_emitPerformanceDataViaDeferredAnonymousFunc() {
 	defer plugin.ReturnCheckResults()
 
 	// Collect last minute details just before ending plugin execution.
-	defer func(exitState *nagios.Plugin, start time.Time) {
+	defer func(plugin *nagios.Plugin, start time.Time) {
 
 		// Record plugin runtime, emit this metric regardless of exit
 		// point/cause.
@@ -78,7 +78,7 @@ func Example_emitPerformanceDataViaDeferredAnonymousFunc() {
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
 		}
-		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+		if err := plugin.AddPerfData(false, runtimeMetric); err != nil {
 			log.Printf("failed to add time (runtime) performance data metric: %v", err)
 			plugin.Errors = append(plugin.Errors, err)
 		}

--- a/exported_test.go
+++ b/exported_test.go
@@ -296,10 +296,10 @@ func TestPerformanceDataIsAfterLongServiceOutput(t *testing.T) {
 	}
 }
 
-// TestEmptyServiceOutputAndManuallyConstructedExitStateProducesNoOutput
+// TestEmptyServiceOutputAndManuallyConstructedPluginProducesNoOutput
 // asserts that an empty ServiceOutput field produces no output when manually
 // constructing the Plugin value.
-func TestEmptyServiceOutputAndManuallyConstructedExitStateProducesNoOutput(t *testing.T) {
+func TestEmptyServiceOutputAndManuallyConstructedPluginProducesNoOutput(t *testing.T) {
 	t.Parallel()
 
 	// Setup Plugin value manually. This approach does not provide the
@@ -337,11 +337,11 @@ func TestEmptyServiceOutputAndManuallyConstructedExitStateProducesNoOutput(t *te
 
 }
 
-// TestEmptyServiceOutputAndConstructedExitStateProducesNoOutput asserts that
+// TestEmptyServiceOutputAndConstructedPluginProducesNoOutput asserts that
 // an empty ServiceOutput field produces no output. We provide a default time
 // metric if client code does not specify one AND if there is ServiceOutput
 // content to emit.
-func TestEmptyServiceOutputAndConstructedExitStateProducesNoOutput(t *testing.T) {
+func TestEmptyServiceOutputAndConstructedPluginProducesNoOutput(t *testing.T) {
 	t.Parallel()
 
 	// Setup Plugin type the same way that client code using the
@@ -375,10 +375,10 @@ func TestEmptyServiceOutputAndConstructedExitStateProducesNoOutput(t *testing.T)
 
 }
 
-// TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric
+// TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric
 // asserts that omitted performance data from client code produces a default
 // time metric when using the Plugin constructor.
-func TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric(t *testing.T) {
+func TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric(t *testing.T) {
 	t.Parallel()
 
 	// Setup Plugin type the same way that client code using the

--- a/unexported_test.go
+++ b/unexported_test.go
@@ -204,10 +204,10 @@ func TestEmptyPerfDataAndEmptyServiceOutputProducesNoOutput(t *testing.T) {
 
 }
 
-// TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric
+// TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric
 // asserts that an empty Performance Data metrics collection AND a constructed
 // Plugin value produces a default time metric in the output.
-func TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric(t *testing.T) {
+func TestEmptyClientPerfDataAndConstructedPluginProducesDefaultTimeMetric(t *testing.T) {
 	t.Parallel()
 
 	// Setup Plugin type the same way that client code using the
@@ -250,11 +250,11 @@ func TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric(t *
 
 }
 
-// TestNonEmptyClientPerfDataAndConstructedExitStateRetainsExistingTimeMetric
+// TestNonEmptyClientPerfDataAndConstructedPluginRetainsExistingTimeMetric
 // asserts that an existing time Performance Data metric is retained when
 // using a constructed Plugin value (which emits a default time metric in
 // the output if NOT specified by client code).
-func TestNonEmptyClientPerfDataAndConstructedExitStateRetainsExistingTimeMetric(t *testing.T) {
+func TestNonEmptyClientPerfDataAndConstructedPluginRetainsExistingTimeMetric(t *testing.T) {
 	t.Parallel()
 
 	// Setup Plugin type the same way that client code using the


### PR DESCRIPTION
Missed some references in test names, example code.