### PR TITLE
Fix TestPerformanceDataIsNotDuplicated test

### DIFF
--- a/unexported_test.go
+++ b/unexported_test.go
@@ -77,25 +77,25 @@ func TestPerformanceDataIsNotDuplicated(t *testing.T) {
 
 	// Collection of performance data with duplicate entries.
 	pd := []PerformanceData{
-		{
+		{ // first performance data entry
 			Label: "test1",
-			Value: "first performance data entry",
+			Value: "1",
 		},
-		{
+		{ // repeated
 			Label: "test1",
-			Value: "first performance data entry, repeated",
+			Value: "1",
 		},
-		{
+		{ // repeated with Label in all upper case
 			Label: "TEST1",
-			Value: "first performance data entry, repeated with all upper case",
+			Value: "1",
 		},
-		{
+		{ // repeated with Label in mixed case
 			Label: "teST1",
-			Value: "first performance data entry, repeated with mixed case",
+			Value: "1",
 		},
-		{
+		{ // first non-duplicate Label
 			Label: "test2",
-			Value: "not a duplicate",
+			Value: "1",
 		},
 	}
 
@@ -107,7 +107,7 @@ func TestPerformanceDataIsNotDuplicated(t *testing.T) {
 	// collection.
 	pd = append(pd, PerformanceData{
 		Label: "test1",
-		Value: "first performance data entry, repeated by itself",
+		Value: "1",
 	})
 
 	if err := plugin.AddPerfData(false, pd...); err != nil {


### PR DESCRIPTION
Test began failing with work on PR branch for PR-175 which expanded validation support for PerformanceData field values.

The previous test metric values used words in place of expected field values:

- literal "U"
- character or values in the regex character class "[-0-9.]"

This commit moves the self-documenting Value field strings to slice element comments and replaces them with placeholder numeric values which pass Value field validation.

refs GH-175