### PR TITLE
Fix revive linting errors

### DIFF
--- a/example_constants_test.go
+++ b/example_constants_test.go
@@ -18,17 +18,25 @@ import (
 // per https://go.dev/blog/examples.
 var _ = "https://github.com/atc0005/go-nagios"
 
-// ExampleUsingOnlyTheProvidedConstants is a simple example that illustrates
+// Example_usingOnlyTheProvidedExitCodeConstants is a simple example that
+// illustrates using only the provided exit code constants from this package.
+// After you've imported this library, reference the exported data types as
+// you would from any other package.
+func Example_usingOnlyTheProvidedExitCodeConstants() {
+	// In this example, we reference a specific exit code for the OK state:
+	fmt.Println("OK: All checks have passed")
+
+	os.Exit(nagios.StateOKExitCode)
+}
+
+// Example_usingOnlyTheProvidedConstants is a simple example that illustrates
 // using only the provided constants from this package. After you've imported
 // this library, reference the exported data types as you would from any other
 // package.
 func Example_usingOnlyTheProvidedConstants() {
-	// In this example, we reference a specific exit code for the OK state:
-	fmt.Println("OK: All checks have passed")
-	os.Exit(nagios.StateOKExitCode)
-
-	// You can also use the provided state "labels" to avoid using literal
-	// string state values (recommended):
+	// In this example, we reference a specific exit code for the OK state and
+	// also use the provided state "labels" to avoid using literal string
+	// state values (recommended):
 	fmt.Printf(
 		"%s: All checks have passed%s",
 		nagios.StateOKLabel,
@@ -36,5 +44,4 @@ func Example_usingOnlyTheProvidedConstants() {
 	)
 
 	os.Exit(nagios.StateOKExitCode)
-
 }

--- a/perfdata.go
+++ b/perfdata.go
@@ -230,11 +230,7 @@ func (pd PerformanceData) Validate() error {
 		return err
 	}
 
-	if err := validatePerfDataMaxField(pd.Max); err != nil {
-		return err
-	}
-
-	return nil
+	return validatePerfDataMaxField(pd.Max)
 }
 
 // String provides a PerformanceData metric in format ready for use in plugin


### PR DESCRIPTION
- Split `Example_usingOnlyTheProvidedConstants` function to resolve `unreachable-code` linting error
- Fix `if-return` revive linting error