### PR TITLE
Add "quick" Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ pristine: goclean gitclean
 all: clean build
 	@echo "Completed build process ..."
 
+.PHONY: quick
+## quick: alias for build recipe
+quick: clean build
+	@echo "Completed tasks for quick build"
+
 .PHONY: build
 ## build: ensure that packages build
 build:


### PR DESCRIPTION
Add the `quick` Makefile recipe to support shared CI workflows.

refs atc0005/shared-project-resources#5