### PR TITLE
Provide `Plugin.AddUniqueError` with dedupe behavior

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -373,6 +373,25 @@ func (p *Plugin) AddError(errs ...error) {
 	p.Errors = append(p.Errors, errs...)
 }
 
+// AddUniqueError appends provided errors to the collection if they are not
+// already present. If a given error is already in the collection then it will
+// be skipped.
+//
+// Errors are evaluated using case-insensitive string comparison.
+func (p *Plugin) AddUniqueError(errs ...error) {
+	existingErrStrings := make([]string, 0, len(p.Errors))
+	for i := range p.Errors {
+		existingErrStrings[i] = p.Errors[i].Error()
+	}
+
+	for _, err := range errs {
+		if inList(err.Error(), existingErrStrings, true) {
+			continue
+		}
+		p.Errors = append(p.Errors, err)
+	}
+}
+
 // SetOutputTarget assigns a target for Nagios plugin output. By default
 // output is emitted to os.Stdout.
 func (p *Plugin) SetOutputTarget(w io.Writer) {

--- a/textutils.go
+++ b/textutils.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Adam Chalkley
+//
+// https://github.com/atc0005/go-nagios
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package nagios
+
+import "strings"
+
+// inList is a helper function to emulate Python's `if "x" in list:`
+// functionality. The caller can optionally ignore case of compared items.
+func inList(needle string, haystack []string, ignoreCase bool) bool {
+	for _, item := range haystack {
+
+		if ignoreCase {
+			if strings.EqualFold(item, needle) {
+				return true
+			}
+		}
+
+		if item == needle {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
In contrast to `Plugin.AddError` which does not provide deduplication of errors before growing the collection, the `Plugin.AddUniqueError` method *does* provide deduplication.

The dedupe behavior is provided by case-insensitive comparison of the error string for the provided error against existing errors already in the collection.

fixes GH-214