### PR TITLE
Better regexp for validating thresholds

### DIFF
--- a/perfdata.go
+++ b/perfdata.go
@@ -38,7 +38,7 @@ const (
 
 	// perfDataThresholdRangeSyntaxRegex represents the regex character class
 	// used to validate and parse the Warn and Crit fields.
-	perfDataThresholdRangeSyntaxRegex string = `[0-9~@:]+`
+	perfDataThresholdRangeSyntaxRegex string = `(^\d+$)|(^\d+:$)|(^~:\d+$)|(^\d+:\d+$)|(^@\d+$)|(^@\d+:$)|(^@~:\d+$)|(^@\d+:\d+$)|(^~:$)`
 
 	// perfDataLabelFieldDisallowedCharacters are the characters disallowed in
 	// the Label field; the equals sign and single quote characters are not


### PR DESCRIPTION
I've observed panic when we were attempting to use some silly, not correct thresholds like:
 - `@4:~`
 - `::`
 - `~:~`
 - `@@`
 - and so on...

It this MR I'm proposing little more strict regexp to validate this.
I think that I've covered all the cases from https://nagios-plugins.org/doc/guidelines.html