### PR TITLE
Fix panic if ParseRangeCheck returns nil

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -96,6 +96,9 @@ var (
 	// metric is not in a supported format.
 	ErrInvalidPerformanceDataFormat = errors.New("invalid performance data format")
 
+	// ErrInvalidRangeThreshold indicates that a given range threshold is not in a supported format.
+	ErrInvalidRangeThreshold = errors.New("invalid range threshold")
+
 	// TODO: Should we use field-specific errors or is the more general
 	// ErrInvalidPerformanceDataFormat "good enough" ? Wrapped versions of
 	// that error will likely already indicate which field is a problem, but

--- a/range.go
+++ b/range.go
@@ -9,6 +9,7 @@
 package nagios
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -149,6 +150,11 @@ func (p *Plugin) EvaluateThreshold(perfData ...PerformanceData) error {
 		if perfData[i].Crit != "" {
 
 			CriticalThresholdObject := ParseRangeString(perfData[i].Crit)
+			if CriticalThresholdObject == nil {
+				err := fmt.Errorf("failed to parse critical range string %s: %w ", perfData[i].Crit, ErrInvalidRangeThreshold)
+				p.ExitStatusCode = StateUNKNOWNExitCode
+				return err
+			}
 
 			if CriticalThresholdObject.CheckRange(perfData[i].Value) {
 				p.ExitStatusCode = StateCRITICALExitCode
@@ -158,6 +164,11 @@ func (p *Plugin) EvaluateThreshold(perfData ...PerformanceData) error {
 
 		if perfData[i].Warn != "" {
 			warningThresholdObject := ParseRangeString(perfData[i].Warn)
+			if warningThresholdObject == nil {
+				err := fmt.Errorf("failed to parse warning range string %s: %w ", perfData[i].Warn, ErrInvalidRangeThreshold)
+				p.ExitStatusCode = StateUNKNOWNExitCode
+				return err
+			}
 
 			if warningThresholdObject.CheckRange(perfData[i].Value) {
 				p.ExitStatusCode = StateWARNINGExitCode


### PR DESCRIPTION
this PR adds checking of nil returns from ParseRangeString in EvaluateThreshold. it returns UNKNOWN state result and an error message.

second I added 2 tests to check this expected behavior

fixes #233, replace #234