### PR TITLE
Fix test case validity check

### DIFF
--- a/nagios.go
+++ b/nagios.go
@@ -557,6 +557,12 @@ func (p *Plugin) UnencodedPayload() string {
 	return p.encodedPayloadBuffer.String()
 }
 
+// defaultPluginOutputTarget returns the fallback/default plugin output target
+// used when a user-specified value is not provided.
+func defaultPluginOutputTarget() io.Writer {
+	return os.Stdout
+}
+
 // emitOutput writes final plugin output to the previously set output target.
 // No further modifications to plugin output are performed.
 func (p Plugin) emitOutput(pluginOutput string) {

--- a/unexported_test.go
+++ b/unexported_test.go
@@ -93,11 +93,12 @@ func TestPluginSetOutputTargetIsValidWithInvalidInput(t *testing.T) {
 	t.Log("Attempting to set invalid output target. This should cause the default output sink to be set instead.")
 	plugin.SetOutputTarget(nil)
 
-	// Assert that plugin.outputSink is set to a non-nil default/fallback
-	// value as expected.
-	if plugin.outputSink == nil {
+	switch {
+	case plugin.outputSink == nil:
+		t.Fatal("ERROR: plugin outputSink is still unset.")
+	case plugin.outputSink != defaultPluginOutputTarget():
 		t.Fatal("ERROR: plugin outputSink is not at the expected default/fallback value.")
-	} else {
+	default:
 		t.Log("OK: plugin outputSink is at the expected default/fallback value.")
 	}
 }


### PR DESCRIPTION
Update `TestPluginSetOutputTargetIsValidWithInvalidInput` to not just assert that plugin.outputSink is set when an invalid output target is specified, but also that it is specifically set to the default plugin output target as intended.

- refs GH-268
- refs GH-267