### PR TITLE
Update `logPluginOutputSize` calls for consistency

### DIFF
--- a/sections.go
+++ b/sections.go
@@ -39,7 +39,7 @@ func (p Plugin) handleServiceOutputSection(w io.Writer) {
 		panic("Failed to write ServiceOutput to given output sink")
 	}
 
-	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin ServiceOutput content written to buffer", written))
+	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin ServiceOutput content written to given output sink", written))
 }
 
 // handleErrorsSection is a wrapper around the logic used to handle/process
@@ -89,7 +89,7 @@ func (p Plugin) handleErrorsSection(w io.Writer) {
 		}
 	}
 
-	p.logPluginOutputSize(fmt.Sprintf("%d bytes total plugin errors content written to buffer", totalWritten))
+	p.logPluginOutputSize(fmt.Sprintf("%d bytes total plugin errors content written to given output sink", totalWritten))
 }
 
 // handleThresholdsSection is a wrapper around the logic used to
@@ -153,7 +153,7 @@ func (p Plugin) handleThresholdsSection(w io.Writer) {
 		totalWritten += written
 	}
 
-	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin thresholds section content written to buffer", totalWritten))
+	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin thresholds section content written to given output sink", totalWritten))
 }
 
 // handleLongServiceOutput is a wrapper around the logic used to
@@ -218,7 +218,7 @@ func (p Plugin) handleLongServiceOutput(w io.Writer) {
 
 	totalWritten += written
 
-	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin LongServiceOutput content written to buffer", totalWritten))
+	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin LongServiceOutput content written to given output sink", totalWritten))
 }
 
 // handleEncodedPayload is a wrapper around the logic used to handle/process
@@ -287,7 +287,7 @@ func (p Plugin) handleEncodedPayload(w io.Writer) {
 		totalWritten += written
 	}
 
-	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin EncodedPayload content written to buffer", totalWritten))
+	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin EncodedPayload content written to given output sink", totalWritten))
 }
 
 // handlePerformanceData is a wrapper around the logic used to
@@ -346,7 +346,7 @@ func (p *Plugin) handlePerformanceData(w io.Writer) {
 
 	totalWritten += written
 
-	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin performance data content written to buffer", totalWritten))
+	p.logPluginOutputSize(fmt.Sprintf("%d bytes plugin performance data content written to given output sink", totalWritten))
 
 }
 


### PR DESCRIPTION
Replace indicators of writing to a buffer (something the logging calls can't know) with writing to a given output sink (which matches the language used nearby.