### PR TITLE
Update README to correct redundant statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ such time that the API is considered stable.
 - Support for adding/embedding a compressed and encoded payload in plugin
   output
 - Support for decoding and decompressing encoded input (payload)
-- Support for extracting, decoding and decompressing an encoded payload from
-  captured plugin output
+- Support for extracting (without decoding & decompressing) an encoded payload
+  from captured plugin output
 - Support for extracting, decoding and decompressing an encoded payload (into
   the original non-encoded form) from captured plugin output
 - Optional debug logging for plugin activity


### PR DESCRIPTION
Clarify that support is available to extract a payload from given input *without* decoding and decompressing the contents in addition to the all-in-one behavior (of performing all of those steps) available as a separate function.

refs GH-301