### PR TITLE
Add tests for plugin output size

### DIFF
--- a/testdata/plugin-output-multiline-with-optional-perf-data-included.txt
+++ b/testdata/plugin-output-multiline-with-optional-perf-data-included.txt
@@ -1,0 +1,22 @@
+OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs) is 0.01% of 18.0TB with 18.0TB remaining [WARNING: 90% , CRITICAL: 95%] 
+**THRESHOLDS** 
+ 
+* CRITICAL: 95% datastore usage 
+* WARNING: 90% datastore usage 
+ 
+**DETAILED INFO** 
+ 
+Datastore Space Summary: 
+ 
+* Name: HUSVM-DC1-vol6 
+* Space Used: 2.3GB (0.01%) 
+* Space Remaining: 18.0TB (99.99%) 
+* VMs: 0  
+ 
+ 
+--- 
+ 
+* vSphere environment: https://vc1.example.com:443/sdk 
+* Plugin User Agent: check-vmware/v0.30.6-0-g25fdcdc 
+ 
+ | 'time'=874ms;;;; 'plugin_output_size'=530B;;;; 

--- a/testdata/plugin-output-one-line-with-optional-perf-data-included.txt
+++ b/testdata/plugin-output-one-line-with-optional-perf-data-included.txt
@@ -1,0 +1,1 @@
+OK: Datastore HUSVM-DC1-vol6 space usage (0 VMs) is 0.01% of 18.0TB with 18.0TB remaining [WARNING: 90% , CRITICAL: 95%] | 'time'=874ms;;;; 'plugin_output_size'=171B;;;; 


### PR DESCRIPTION
- rename existing one-line and multi-line performance data metric tests to reflect that they're testing for default performance data metrics
- add new testdata input files for "all optional" performance data metrics tests
- add new tests intended to assert that all optional performance data metrics are emitted *and* that the plugin output size is properly calculated
  - later refactoring willl likely lead to separating these two goals into different tests

refs GH-324