### PR TITLE
Bump minimum Go version from 1.19 to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/go-nagios
 
-go 1.19
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
## Changes

The `github.com/google/go-cmp` dependency bumped its minimum Go version from Go 1.13 to 1.21 as of the v0.7.0 release.

Since this project depends on it, we either have to also bump the minimum Go version or find a way to move all tests into a separate module. Since some tests currently access unexported values (fields, methods, functions, etc.), this won't be a simple change.

For now, bumping the minimum Go version is the easiest path forward.

## References

- fixes GH-341